### PR TITLE
Fix PostgreSQL volume path in docker-compose.yml

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,7 +7,7 @@ services:
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: authentik
     volumes:
-      - postgresql:/var/lib/postgresql/data
+      - postgresql:/var/lib/postgresql
     networks:
       - default
     healthcheck:


### PR DESCRIPTION
Correct the volume path for PostgreSQL in the docker-compose configuration.