### PR TITLE
Add PGDATA environment variable for PostgreSQL service

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,6 +6,7 @@ services:
       POSTGRES_USER: authentik
       POSTGRES_PASSWORD: ${POSTGRES_PASSWORD}
       POSTGRES_DB: authentik
+      PGDATA: /var/lib/postgresql
     volumes:
       - postgresql:/var/lib/postgresql
     networks:


### PR DESCRIPTION
Introduce the PGDATA environment variable to specify the data directory for the PostgreSQL service.